### PR TITLE
R simulation and extremely significant perf improvement for the julia simulation

### DIFF
--- a/simulate.R
+++ b/simulate.R
@@ -1,0 +1,105 @@
+library(dplyr, warn.conflicts = FALSE)
+library(ggplot2)
+
+simulate <- function (n) {
+    df <- data.frame(
+        x = rnorm(n, sd = 0.1),
+        y = rnorm(n, sd = 0.1),
+        E = rexp(n)
+    )
+
+    ## When a particle is frozen, we retrieve its final x and y position.
+    df_frozen <- data.frame(
+        x = double(),
+        y = double(),
+        E = double()
+    )
+
+    while (nrow(df) > 0) {
+        df <- df |>
+            mutate(
+                x = x + rnorm(n(), sd = 0.1),
+                y = y + rnorm(n(), sd = 0.1),
+                ## If energy is transferred, it is 10% of the current value.
+                ee = E * 0.1,
+                ## Energy always reduces by 10% each iteration, transfer or not.
+                E = E * 0.9
+            )
+
+        ## Determine the cumulative energy transferred to any other particles.
+        e_updates <- df |>
+            select(ee) |>
+            ## 50% chance to radiate energy to another active particle.
+            filter(sample(c(T, F), n(), replace = TRUE)) |>
+            ## Sample all the other active particles, one for each radiating one.
+            mutate(p = sample(1:nrow(df), n(), replace = TRUE)) |>
+            ## Sum the ee results over all duplicates of the target particle, producing a table with
+            ## exactly one entry for each distinct target.
+            summarize(sum_ee = sum(ee), .by = p)
+        df <- df |>
+            select(!ee) |>
+            ## dplyr makes joining against row number more efficient than any manual iteration.
+            mutate(p = row_number()) |>
+            ## Joins produce NA for non-matching rows.
+            left_join(e_updates, by = "p") |>
+            ## Add the ee sum if available, or 0.
+            mutate(E = E + if_else(!is.na(sum_ee), sum_ee, 0)) |>
+            ## p's work here is done.
+            select(x:E)
+
+        ## NB: dplyr claims group_split() is unstable and proposes nest(), but that's ridiculously
+        ## slower here so we don't use it: https://dplyr.tidyverse.org/reference/group_split.html#lifecycle
+        by_frozen <- df |>
+            mutate(xy = (x^2 + y^2)) |>
+            mutate(inregion = (xy < 1) | (abs(x) < 0.5 & y > -2.0 & y < 0.0)) |>
+            ## NB: this is by far the slowest line
+            group_split(inregion)
+        stopifnot(length(by_frozen) <= 2)
+
+        ## Clear out the data frame variable we check against for iteration now. If there are no
+        ## remaining values, there will be no group returned by group_split() where inregion == TRUE
+        ## (a length 1 result), and we indeed wish to return in that case.
+        df <- data.frame()
+
+        first_in_region <- by_frozen[[1]]$inregion[1]
+        first_value <- by_frozen[[1]] |> select(!inregion, !xy)
+        if (first_in_region) {
+            df <- first_value
+        } else {
+            df_frozen <- df_frozen |> bind_rows(first_value)
+        }
+
+        if (length(by_frozen) == 1) {
+            next;
+        }
+
+        second_in_region <- by_frozen[[2]]$inregion[1]
+        stopifnot(second_in_region == !first_in_region)
+        second_value <- by_frozen[[2]] |> select(!inregion)
+        if (second_in_region) {
+            df <- second_value
+        } else {
+            df_frozen <- df_frozen |> bind_rows(second_value)
+        }
+    }
+
+    df_frozen
+}
+
+if (!interactive()) {
+    df_done <- simulate(1000000)
+
+    p1 <- ggplot(df_done, aes(log(E))) +
+        geom_histogram(binwidth = 0.01) +
+        labs(x = NULL, y = NULL, title = "Log(E) at exit")
+
+    ggsave("particles-r1.png", p1)
+
+
+    p2 <- ggplot(df_done, aes(x, y, color = log(E))) +
+        geom_point(alpha = 0.05, size = 2) +
+        scale_color_gradient(low = "#042333", high = "#E8FA5B") +
+        labs(title = "Final Position with color from log(E)")
+
+    ggsave("particles-r2.png", p2)
+}

--- a/simulate.jl
+++ b/simulate.jl
@@ -33,8 +33,6 @@ function uninit_array_alloc{T}(len) where {T}
 end
 
 function simulate(N)
-    Random.seed!(111)
-
     local positions = rand(Normal(0, 0.1), N, POSITION_COORDINATES)
     local energies = rand(Exponential(1.0), N)
     # very surprised there's no b-tree for sparse orderable inputs!

--- a/simulate.jl
+++ b/simulate.jl
@@ -1,63 +1,175 @@
-using CSV,DataFrames,StatsPlots,DataFramesMeta,DataStructures,Distributions
-using Pkg
-Pkg.activate(".")
+using DataStructures, Distributions, Random, LinearAlgebra
 
-mutable struct Particle
-    n::Int64
-    x::Float64
-    y::Float64
-    E::Float64
+function msg(s)
+    # println(s)
 end
 
-function inregion(x,y)
-    return x^2+y^2 < 1 || (abs(x) < 0.5 && y > -2.0 && y < 0.0);
+function pr(o)
+    # show(stdout, "text/plain", o)
+    # println()
+end
+
+const POSITION_COORDINATES::UInt = 2
+
+function squash_scratch_space(scratch_matrix::Matrix{T}, remaining_entries::UInt)::Matrix{T} where T
+    # TODO: Julia has no builtin type to codify this expectation!
+    @boundscheck !iszero(remaining_entries)
+
+    # If we have fewer active particles than we did last iteration, this will take a contiguous
+    # subset of the underlying memory from the start of the allocation region, then reinterpret
+    # this so we maintain the same number of columns.
+    scratch_matrix = @views reshape(
+        scratch_matrix[1:(remaining_entries * POSITION_COORDINATES)],
+        :,
+        POSITION_COORDINATES
+    )
+    # This doesn't matter to us since we are about to completely clobber the data anyway, but
+    # this will result in data sliding across consecutive columns. This ensures we conform to
+    # julia's column-major encoding: https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-column-major
+    @assert size(scratch_matrix) == (remaining_entries, POSITION_COORDINATES)
+
+    scratch_matrix
 end
 
 
-function simulate(N)
-    active = Set{Particle}()
-    sizehint!(active,N)
-    for i in 1:N
-        union!(active,(Particle(i,rand(Normal(0,0.1)),rand(Normal(0,0.1)),rand(Exponential(1.0))),))
-    end 
-    frozen = Set{Particle}()
-    sizehint!(frozen,N)
+# This indirection appears necessary in order to get explicit type parameters that aren't inferred
+# away: https://docs.julialang.org/en/v1/manual/constructors/#Case-Study:-Rational
+struct uninit_array_alloc{T}
+end
+function uninit_array_alloc{T}(len) where {T}
+    local ret = Array{T}(undef, len)
+    resize!(ret, 0)
+    ret
+end
+
+struct hinted_dict_alloc{K,V}
+end
+function hinted_dict_alloc{K, V}(len) where {K, V}
+    local n::Int = len
+    local ret = Dict{K, V}()
+    sizehint!(ret, n)
+    ret
+end
+
+function simulate(N::UInt)
+    Random.seed!(111)
+
+    local positions = rand(Normal(0, 0.1), N, POSITION_COORDINATES)
+    local energies = rand(Exponential(1.0), N)
+    # very surprised there's no b-tree for sparse orderable inputs!
+    local active = BitSet(1:N)
+
+    local cur_indices = uninit_array_alloc{UInt}(N)
+
+    local radiated_energy = uninit_array_alloc{Float64}(N)
+    local cur_energies = uninit_array_alloc{Float64}(N)
+
+    local radiation_updates = hinted_dict_alloc{UInt, Float64}(N)
+
+    local interaction_targets = uninit_array_alloc{UInt}(N)
+
+    # This is our scratch space to cover the current position indices.
+    local cur_positions = Matrix{Float64}(undef, N, POSITION_COORDINATES)
+    # This is also scratch space, but for random position perturbations as opposed to the
+    # position array.
+    local rand_offsets = Matrix{Float64}(undef, N, POSITION_COORDINATES)
+
     while ! isempty(active)
+        resize!(cur_indices, 0)
         for i in active
-            i.x = i.x + rand(Normal(0,0.1))
-            i.y = i.y + rand(Normal(0,0.1))
-            if rand() < 0.5
-                i.E = i.E * 0.9 ## 50% chance to lose 10% to radiation
-            else
-                # 50% chance to radiate energy to another active particle
-                # select a random active particle and give it 10% of the energy via radiation
-                ee = i.E * 0.1
-                i.E *= 0.9
-                p = rand(active)
-                p.E = p.E + ee
-            end
-            if !inregion(i.x,i.y)
-                union!(frozen,(i,))
-            end
+            push!(cur_indices, i)
         end
-        active = setdiff(active,frozen)
+
+        # Squash our scratch spaces down to size.
+        cur_positions = squash_scratch_space(cur_positions, convert(UInt, length(cur_indices)))
+        rand_offsets = squash_scratch_space(rand_offsets, convert(UInt, length(cur_indices)))
+
+        # Copy the possibly-noncontiguous position data from the main array into our scratch space.
+        cur_positions .= positions[cur_indices,:]
+
+        # Perturb x and y positions of all remaining points.
+        rand!(Normal(0, 0.1), rand_offsets)
+        cur_positions .+= rand_offsets
+
+        # Radiation targets receive 10% of current energy.
+        resize!(radiated_energy, length(cur_indices))
+        radiated_energy .= energies[cur_indices] .* 0.1
+        # local radiated_energy = energies[cur_indices] .* 0.1
+        # Energy decreases by 10% upon each step.
+        energies[cur_indices] .*= 0.9
+
+        # Calculate any particle interactions from this iteration.
+        local interacts_with = bitrand(length(cur_indices))
+        local radiated_interactions = radiated_energy[interacts_with]
+        resize!(interaction_targets, length(radiated_interactions))
+        rand!(interaction_targets, cur_indices)
+
+        # Calculate x^2 + y^2 by squaring the euclidean norm.
+        local xy = norm.(eachrow(cur_positions)) .^ 2
+
+        local val_x = @view cur_positions[:,1]
+        local val_y = @view cur_positions[:,2]
+
+        local xy_valid = xy .< 1
+        local x_valid = abs.(val_x) .< 0.5
+        local y_valid = -2.0 .< val_y .< 0.0
+        # Calculate region boundary check in a vectorized way.
+        local in_region = xy_valid .| (x_valid .& y_valid)
+
+        # Write our modified position data back to the main array.
+        positions[cur_indices,:] .= cur_positions
+
+        # Update active particles for next iteration.
+        local newly_frozen = cur_indices[.~in_region]
+        setdiff!(active, newly_frozen)
+
+        # Calculate cumulative radiation interaction updates.
+        empty!(radiation_updates)
+
+        # Coalesce all energy updates over potentially-duplicated targets:
+        for (new_energy, cur_target) in zip(radiated_interactions, interaction_targets)
+            get!(radiation_updates, cur_target, 0.0)
+            radiation_updates[cur_target] += new_energy
+        end
+
+        local shared_targets = Array{UInt}(undef, length(interaction_targets))
+        resize!(shared_targets, 0)
+        local cumulative_new_energies = Array{Float64}(undef, length(interaction_targets))
+        resize!(cumulative_new_energies, 0)
+        for (shared_target, cumulative_new_energy) in radiation_updates
+            push!(shared_targets, shared_target)
+            push!(cumulative_new_energies, cumulative_new_energy)
+        end
+        energies[shared_targets] .+= cumulative_new_energies
     end
-    return frozen
+
+    (positions, energies)
 end
 
+function execute()
+    # positions, energies = @time simulate(1_000_000)
+    local positions, energies = @time simulate(convert(UInt, 1_00))
 
+    local colors = cgrad(:thermal)
+    local p1 = histogram(log.(energies), label=false, title="Log(E) at exit")
+    local p2 = scatter(
+        # eachrow(positions),
+        [(r[1], r[2]) for r in eachrow(positions)],
+        # eachrow(positions),
+        marker_z=log.(energies),
+        alpha=0.05, pointsize=2, color=colors, label=false,
+        title="Final Position with color from log(E)")
 
+    plot(
+        p1, p2,
+        layout=(2,1),
+        size=(400,800),
+    )
+    savefig("particles.png")
+    println("The 99.95% quantile of energy was: $(quantile(energies, .9995))")
+end
 
-parts = @time simulate(1_000_000)
-
-
-colors = cgrad(:thermal)
-p1 = histogram([log(part.E) for part in parts],label=false,title="Log(E) at exit");
-p2 = scatter([(p.x,p.y) for p in parts],alpha=0.05,pointsize=2,marker_z=[log(p.E) for p in parts],
-    color=colors,label=false,title="Final Position with color from log(E)");
-
-plot(p1,p2,layout=(2,1),size=(400,800))
-savefig("particles.png")
-println("The 99.95% quantile of energy was: $(quantile([p.E for p in parts],.9995))")
-
-
+if !isinteractive()
+    using StatsPlots
+    execute()
+end


### PR DESCRIPTION
This approach uses dplyr database operations to achieve the set-based approach performed by the julia version. In particular:
- it maintains data in columns (struct-of-arrays vs array-of-structs).
  - this becomes relevant for the `inregion` calculation, which is able to work in a vectorized fashion.
- it enforces uniqueness via row index, which allows it to express the particle radiation as a join.
  - very important: the "set" being used in the julia version is not actually making use of the set for performance.

I had some more thorough comments on the R version earlier, and then spent a very long time learning Julia. I need to take some time to sleep now but this julia version I have is able to do everything the R code can, as well as significantly more. I have the actual analysis running in 4.5 seconds on my laptop--serializing the output to a graph takes a further 45 seconds or so (maybe this is an upstream inefficiency we could look into?).

I am incredibly deeply impressed with the Julia programming language. I'm utterly astonished. Really incredible tool in a ridiculous number of very small and significant ways. Love it. Thanks so much for introducing me to to it :D ^_^!